### PR TITLE
Fix .Net Core Issues #37 with BeginInvoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,8 @@
 *.user
 *.userosscache
 *.sln.docstates
-
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
-
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
@@ -21,27 +19,21 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
-
 # Visual Studio 2015 cache/options directory
 .vs/
-
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
-
 # NUNIT
 *.VisualState.xml
 TestResult.xml
-
 # Build Results of an ATL Project
 [Dd]ebugPS/
 [Rr]eleasePS/
 dlldata.c
-
 # DNX
 project.lock.json
 artifacts/
-
 *_i.c
 *_p.c
 *_i.h
@@ -66,10 +58,8 @@ artifacts/
 *.pidb
 *.svclog
 *.scc
-
 # Chutzpah Test files
 _Chutzpah*
-
 # Visual C++ cache files
 ipch/
 *.aps
@@ -77,46 +67,34 @@ ipch/
 *.opensdf
 *.sdf
 *.cachefile
-
 # Visual Studio profiler
 *.psess
 *.vsp
 *.vspx
-
 # TFS 2012 Local Workspace
 $tf/
-
 # Guidance Automation Toolkit
 *.gpState
-
 # ReSharper is a .NET coding add-in
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
-
 # JustCode is a .NET coding add-in
 .JustCode
-
 # TeamCity is a build add-in
 _TeamCity*
-
 # DotCover is a Code Coverage Tool
 *.dotCover
-
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
-
 # MightyMoose
 *.mm.*
 AutoTest.Net/
-
 # Web workbench (sass)
 .sass-cache/
-
 # Installshield output folder
 [Ee]xpress/
-
 # DocProject is a documentation generator add-in
 DocProject/buildhelp/
 DocProject/Help/*.HxT
@@ -126,10 +104,8 @@ DocProject/Help/*.hhk
 DocProject/Help/*.hhp
 DocProject/Help/Html2
 DocProject/Help/html
-
 # Click-Once directory
 publish/
-
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
@@ -137,9 +113,7 @@ publish/
 ## web deploy settings but do note that will include unencrypted
 ## passwords
 #*.pubxml
-
 *.publishproj
-
 # NuGet Packages
 *.nupkg
 # The packages folder can be ignored because of Package Restore
@@ -148,20 +122,16 @@ publish/
 !**/packages/build/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
-
 # Windows Azure Build Output
 csx/
 *.build.csdef
-
 # Windows Store app package directory
 AppPackages/
-
 # Visual Studio cache files
 # files ending in .cache can be ignored
 *.[Cc]ache
 # but keep track of directories ending in .cache
 !*.[Cc]ache/
-
 # Others
 ClientBin/
 [Ss]tyle[Cc]op.*
@@ -173,10 +143,8 @@ ClientBin/
 *.publishsettings
 node_modules/
 orleans.codegen.cs
-
 # RIA/Silverlight projects
 Generated_Code/
-
 # Backup & report files from converting an old project file
 # to a newer Visual Studio version. Backup files are not needed,
 # because we have git ;-)
@@ -184,28 +152,21 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
-
 # SQL Server files
 *.mdf
 *.ldf
-
 # Business Intelligence projects
 *.rdl.data
 *.bim.layout
 *.bim_*.settings
-
 # Microsoft Fakes
 FakesAssemblies/
-
 # Node.js Tools for Visual Studio
 .ntvs_analysis.dat
-
 # Visual Studio 6 build log
 *.plg
-
 # Visual Studio 6 workspace options file
 *.opt
-
 # LightSwitch generated files
 GeneratedArtifacts/
 _Pvt_Extensions/

--- a/JamaaTech.SMPP.Net.Lib/Networking/TcpIpSession.cs
+++ b/JamaaTech.SMPP.Net.Lib/Networking/TcpIpSession.cs
@@ -210,8 +210,12 @@ namespace JamaaTech.Smpp.Net.Lib.Networking
             if (SessionClosed == null) { return; }
             foreach (EventHandler<TcpIpSessionClosedEventArgs> del in SessionClosed.GetInvocationList())
             {
+#if NET40
                 SessionClosed.BeginInvoke(this, new TcpIpSessionClosedEventArgs(reason, ex),
                     AsyncCallBackRaiseSessionClosedEvent, del);
+#else
+                System.Threading.Tasks.Task.Run(() => SessionClosed.Invoke(this, new TcpIpSessionClosedEventArgs(reason, ex)));
+#endif
             }
         }
 
@@ -220,8 +224,12 @@ namespace JamaaTech.Smpp.Net.Lib.Networking
             if (SessionException == null) { return; }
             foreach (EventHandler<TcpIpSessionExceptionEventArgs> del in SessionException.GetInvocationList())
             {
-                del.BeginInvoke(this, new TcpIpSessionExceptionEventArgs(ex), 
+#if NET40
+                del.BeginInvoke(this, new TcpIpSessionExceptionEventArgs(ex),
                     AsyncCallBackRaiseSessionExceptionEvent, del);
+#else
+                System.Threading.Tasks.Task.Run(() => del.Invoke(this, new TcpIpSessionExceptionEventArgs(ex)));
+#endif
             }
         }
 

--- a/JamaaTech.SMPP.Net.Lib/SmppClientSession.cs
+++ b/JamaaTech.SMPP.Net.Lib/SmppClientSession.cs
@@ -202,7 +202,13 @@ namespace JamaaTech.Smpp.Net.Lib
 
         public IAsyncResult BeginSendPdu(RequestPDU pdu, int timeout, AsyncCallback callback, object @object)
         {
+#if NET40
             return vCallback.BeginInvoke(pdu, timeout, callback, @object);
+
+#else
+                return System.Threading.Tasks.Task.Run(() => vCallback(pdu, timeout));
+#endif
+
         }
 
         public IAsyncResult BeginSendPdu(RequestPDU pdu, AsyncCallback callback, object @object)
@@ -491,7 +497,13 @@ namespace JamaaTech.Smpp.Net.Lib
             if (SessionClosed == null) { return; }
             SmppSessionClosedEventArgs e = new SmppSessionClosedEventArgs(reason, exception);
             foreach (EventHandler<SmppSessionClosedEventArgs> del in SessionClosed.GetInvocationList())
-            { del.BeginInvoke(this, e, AsyncCallBackRaiseSessionClosedEvent, del); }
+            {
+#if NET40
+                del.BeginInvoke(this, e, AsyncCallBackRaiseSessionClosedEvent, del);
+#else
+                System.Threading.Tasks.Task.Run(() => del.Invoke(this, e));
+#endif
+            }
         }
 
         private void AsyncCallBackRaiseSessionClosedEvent(IAsyncResult result)

--- a/JamaaTech.SMPP.Net.Lib/StreamParser.cs
+++ b/JamaaTech.SMPP.Net.Lib/StreamParser.cs
@@ -91,8 +91,11 @@ namespace JamaaTech.Smpp.Net.Lib
                     PDU pdu = WaitPDU();
                     if (pdu is RequestPDU)
                     {
-                        vProcessorCallback.BeginInvoke(
-   (RequestPDU)pdu, AsyncCallBackProcessPduRequest, null);
+#if NET40
+                        vProcessorCallback.BeginInvoke((RequestPDU)pdu, AsyncCallBackProcessPduRequest, null);  //old
+#else
+                        System.Threading.Tasks.Task.Run(() => vProcessorCallback.Invoke((RequestPDU)pdu));      //new
+#endif
                     }
                     else if (pdu is ResponsePDU) { vResponseHandler.Handle(pdu as ResponsePDU); }
                 }
@@ -228,7 +231,13 @@ namespace JamaaTech.Smpp.Net.Lib
             if (PDUError == null) { return; }
             PDUErrorEventArgs e = new PDUErrorEventArgs(exception, byteDump, header, pdu);
             foreach (EventHandler<PDUErrorEventArgs> del in PDUError.GetInvocationList())
-            { del.BeginInvoke(this, e, AsyncCallBackRaisePduErrorEvent, del); }
+            {
+#if NET40
+                del.BeginInvoke(this, e, AsyncCallBackRaisePduErrorEvent, del);
+#else
+                System.Threading.Tasks.Task.Run(() => del.Invoke(this, e));
+#endif
+            }
         }
 
         private void RaiseParserExceptionEvent(Exception exception)
@@ -236,7 +245,13 @@ namespace JamaaTech.Smpp.Net.Lib
             if (ParserException == null) { return; }
             ParserExceptionEventArgs e = new ParserExceptionEventArgs(exception);
             foreach (EventHandler<ParserExceptionEventArgs> del in ParserException.GetInvocationList())
-            { del.BeginInvoke(this, e, AsyncCallBackRaiseParserExceptionEvent, del); }
+            {
+#if NET40
+                del.BeginInvoke(this, e, AsyncCallBackRaiseParserExceptionEvent, del);
+#else
+                System.Threading.Tasks.Task.Run(() => del.Invoke(this, e));
+#endif
+            }
         }
 
         private void AsyncCallBackRaisePduErrorEvent(IAsyncResult result)

--- a/JamaaTech.Smpp.Net.Client/Smpp.Net.Client.csproj
+++ b/JamaaTech.Smpp.Net.Client/Smpp.Net.Client.csproj
@@ -23,7 +23,7 @@
   <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
     <Message Text="@(ReferenceCopyLocalPaths)" />
     <ItemGroup>
-      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
     </ItemGroup>
   </Target>
 </Project>

--- a/JamaaTech.Smpp.Net.Client/SmppClient.cs
+++ b/JamaaTech.Smpp.Net.Client/SmppClient.cs
@@ -239,7 +239,12 @@ namespace JamaaTech.Smpp.Net.Client
         /// <returns>An <see cref="IAsyncResult"/> that references the asynchronous send message operation</returns>
         public IAsyncResult BeginSendMessage(ShortMessage message, int timeout, AsyncCallback callback, object state)
         {
+#if NET40
             return vSendMessageCallBack.BeginInvoke(message, timeout, callback, state);
+
+#else
+                return System.Threading.Tasks.Task.Run(() => vSendMessageCallBack(message, timeout));
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
`BeginInvoke` raises System.PlatformNotSupportedException when used in a .NET core project.
In .NET core, `BeginInvoke` can be replaced by `System.Threading.Tasks.Task.Run`.
I added an `#if` directive to support dotnet core and NET40 at the same time.