### PR TITLE
Improve handling of multiple messageIds in SmppClient

### DIFF
--- a/JamaaTech.SMPP.Net.Lib/Protocol/AlertNotification.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/AlertNotification.cs
@@ -63,7 +63,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             return null;
         }

--- a/JamaaTech.SMPP.Net.Lib/Protocol/BindRequest.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/BindRequest.cs
@@ -102,7 +102,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
 
         #region Methods
         #region Interface Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             CommandType cmdType = CommandType.BindTransceiverResp;
             switch (vHeader.CommandType)

--- a/JamaaTech.SMPP.Net.Lib/Protocol/CancelSm.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/CancelSm.cs
@@ -57,7 +57,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.CancelSmResp, vHeader.SequenceNumber);
             return new CancelSmResp(header, vSmppEncodingService);

--- a/JamaaTech.SMPP.Net.Lib/Protocol/DataSm.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/DataSm.cs
@@ -43,7 +43,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.DataSmResp, vHeader.SequenceNumber);
             return new DataSmResp(header, vSmppEncodingService);

--- a/JamaaTech.SMPP.Net.Lib/Protocol/DeliverSm.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/DeliverSm.cs
@@ -101,7 +101,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.DeliverSmResp, vHeader.SequenceNumber);
             return new DeliverSmResp(header, vSmppEncodingService);

--- a/JamaaTech.SMPP.Net.Lib/Protocol/EnquireLink.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/EnquireLink.cs
@@ -41,7 +41,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.EnquireLinkResp, vHeader.SequenceNumber);
             //use default Status and Length

--- a/JamaaTech.SMPP.Net.Lib/Protocol/Outbind.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/Outbind.cs
@@ -61,7 +61,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.BindTransceiver, vHeader.SequenceNumber);
             return new BindTransceiverResp(header, vSmppEncodingService);

--- a/JamaaTech.SMPP.Net.Lib/Protocol/QuerySm.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/QuerySm.cs
@@ -42,7 +42,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.QuerySmResp, vHeader.SequenceNumber);
             return new QuerySmResp(header, vSmppEncodingService);

--- a/JamaaTech.SMPP.Net.Lib/Protocol/ReplaceSm.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/ReplaceSm.cs
@@ -102,7 +102,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.ReplaceSm,vHeader.SequenceNumber);
             return new ReplaceSmResp(header, vSmppEncodingService);

--- a/JamaaTech.SMPP.Net.Lib/Protocol/RequestPDU.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/RequestPDU.cs
@@ -31,7 +31,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public abstract ResponsePDU CreateDefaultResponce();
+        public abstract ResponsePDU CreateDefaultResponse();
         #endregion
     }
 }

--- a/JamaaTech.SMPP.Net.Lib/Protocol/SubmitSm.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/SubmitSm.cs
@@ -101,7 +101,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.DeliverSmResp, vHeader.SequenceNumber);
             return new SubmitSmResp(header, vSmppEncodingService);

--- a/JamaaTech.SMPP.Net.Lib/Protocol/SubmitSmResp.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/SubmitSmResp.cs
@@ -63,7 +63,10 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
             //Note that the body part may have not been returned by
             //the SMSC if the command status is not 0
             if (buffer.Length == 0) { return; }
-            vMessageID = DecodeCString(buffer, vSmppEncodingService);
+            if(string.IsNullOrEmpty(vMessageID))
+                vMessageID = DecodeCString(buffer, vSmppEncodingService);
+            else
+                vMessageID+=$":{DecodeCString(buffer, vSmppEncodingService)}";
             //This pdu has no optional parameters,
             //after preceding statements, the buffer must remain with no data
             if (buffer.Length > 0) { throw new TooManyBytesException(); }

--- a/JamaaTech.SMPP.Net.Lib/Protocol/Unbind.cs
+++ b/JamaaTech.SMPP.Net.Lib/Protocol/Unbind.cs
@@ -41,7 +41,7 @@ namespace JamaaTech.Smpp.Net.Lib.Protocol
         #endregion
 
         #region Methods
-        public override ResponsePDU CreateDefaultResponce()
+        public override ResponsePDU CreateDefaultResponse()
         {
             PDUHeader header = new PDUHeader(CommandType.UnBindResp,vHeader.SequenceNumber);
             UnbindResp resp = (UnbindResp)CreatePDU(header, vSmppEncodingService);

--- a/JamaaTech.SMPP.Net.Lib/SmppClientSession.cs
+++ b/JamaaTech.SMPP.Net.Lib/SmppClientSession.cs
@@ -180,7 +180,7 @@ namespace JamaaTech.Smpp.Net.Lib
 
         private void SendPduBase(PDU pdu)
         {
-            if (pdu == null) { throw new ArgumentNullException("pdu"); }
+            if (pdu == null) { throw new ArgumentNullException(nameof(pdu)); }
             if (!(CheckState(pdu) && (pdu.AllowedSource & SmppEntityType.ESME) == SmppEntityType.ESME))
             { throw new SmppException(SmppErrorCode.ESME_RINVBNDSTS, "Incorrect bind status for given command"); }
             try { vTrans.Send(pdu); }
@@ -423,7 +423,7 @@ namespace JamaaTech.Smpp.Net.Lib
             ResponsePDU resp = null;
             if (pdu is Unbind)
             {
-                resp = pdu.CreateDefaultResponce();
+                resp = pdu.CreateDefaultResponse();
                 try { SendPduBase(resp); }
                 catch {/*silent catch*/}
                 EndSession(SmppSessionCloseReason.UnbindRequested, null);
@@ -434,7 +434,7 @@ namespace JamaaTech.Smpp.Net.Lib
             {
                 if (pdu.HasResponse)
                 {
-                    resp = pdu.CreateDefaultResponce();
+                    resp = pdu.CreateDefaultResponse();
                 }
             }
             if (resp != null)
@@ -465,7 +465,7 @@ namespace JamaaTech.Smpp.Net.Lib
             if (e.Pdu is RequestPDU)
             {
                 RequestPDU req = (RequestPDU)e.Pdu;
-                resp = req.CreateDefaultResponce();
+                resp = req.CreateDefaultResponse();
                 resp.Header.ErrorCode = e.Exception.ErrorCode;
             }
             else

--- a/JamaaTech.Smpp.Net.Client/SmppClient.cs
+++ b/JamaaTech.Smpp.Net.Client/SmppClient.cs
@@ -202,7 +202,10 @@ namespace JamaaTech.Smpp.Net.Client
                     if (_Log.IsDebugEnabled) _Log.DebugFormat("SendMessage Response: {0}", LoggingExtensions.DumpString(resp, vSmppEncodingService));
                     messageId = ((SubmitSmResp)resp).MessageID;
                 }
-                message.ReceiptedMessageId = messageId;
+                if(message.ReceiptedMessageId is {Length:>0})
+                    message.ReceiptedMessageId += $",{messageId}";
+                else
+                    message.ReceiptedMessageId += messageId;
                 RaiseMessageSentEvent(message);
             }
         }

--- a/JamaaTech.Smpp.Net.Client/TextMessage.cs
+++ b/JamaaTech.Smpp.Net.Client/TextMessage.cs
@@ -24,11 +24,14 @@ namespace JamaaTech.Smpp.Net.Client
     public class TextMessage : ShortMessage
     {
         #region Variables
+
         private string vText;
         private int vMaxMessageLength;
+
         #endregion
 
         #region Constuctors
+
         /// <summary>
         /// Initializes a new instance of <see cref="TextMessage"/>
         /// </summary>
@@ -43,9 +46,11 @@ namespace JamaaTech.Smpp.Net.Client
         {
             vText = "";
         }
+
         #endregion
 
         #region Properties
+
         /// <summary>
         /// Gets or sets a <see cref="System.String"/> value representing the text content of the message
         /// </summary>
@@ -55,24 +60,20 @@ namespace JamaaTech.Smpp.Net.Client
             set { vText = value; }
         }
 
-        public int MaxMessageLength { get { return vMaxMessageLength; } }
+        public int MaxMessageLength
+        {
+            get { return vMaxMessageLength; }
+        }
+
         #endregion
 
         #region Methods
-        protected override IEnumerable<SendSmPDU> GetPDUs(DataCoding defaultEncoding, SmppEncodingService smppEncodingService, SmppAddress destAddress = null, SmppAddress srcAddress = null)
-        {
-            destAddress = destAddress ?? new SmppAddress() {Address = vDestinatinoAddress};
-            srcAddress = srcAddress ?? new SmppAddress()
-            {
-                Address = vSourceAddress
-            };
-            SubmitSm sm = CreateSubmitSm(smppEncodingService, destAddress, srcAddress );
-            sm.DataCoding = defaultEncoding;
-            if (SubmitUserMessageReference)
-                sm.SetOptionalParamString(Lib.Protocol.Tlv.Tag.user_message_reference, UserMessageReference);
 
-            if (vRegisterDeliveryNotification)
-                sm.RegisteredDelivery = RegisteredDelivery.DeliveryReceipt;
+        protected override IEnumerable<SendSmPDU> GetPDUs(DataCoding defaultEncoding,
+            SmppEncodingService smppEncodingService, SmppAddress destAddress = null, SmppAddress srcAddress = null)
+        {
+            destAddress ??= new SmppAddress() { Address = vDestinatinoAddress };
+            srcAddress ??= new SmppAddress() { Address = vSourceAddress };
 
             vMaxMessageLength = GetMaxMessageLength(defaultEncoding, false);
             byte[] bytes = smppEncodingService.GetBytesFromString(vText, defaultEncoding);
@@ -81,30 +82,43 @@ namespace JamaaTech.Smpp.Net.Client
             // We check vText Length first
             if (vText.Length > vMaxMessageLength && bytes.Length > vMaxMessageLength) // Split into multiple!
             {
-                var SegID = new Random().Next(1000, 9999); // create random SegmentID
+                var segId = new Random().Next(1000, 9999); // create random SegmentID
                 vMaxMessageLength = GetMaxMessageLength(defaultEncoding, true);
                 var messages = Split(vText, vMaxMessageLength);
                 var totalSegments = messages.Count; // get the number of (how many) parts
-                var udh = new Udh(SegID, totalSegments, 0); // ID, Total, part
 
                 for (int i = 0; i < totalSegments; i++)
                 {
-                    udh.MessageSequence = i + 1;  // seq+1 , - parts of the message      
+                    SubmitSm sm = CreateSubmitSm(smppEncodingService, destAddress, srcAddress);
+                    sm.DataCoding = defaultEncoding;
+                    if (SubmitUserMessageReference)
+                        sm.SetOptionalParamString(Lib.Protocol.Tlv.Tag.user_message_reference, UserMessageReference);
+
+                    if (vRegisterDeliveryNotification)
+                        sm.RegisteredDelivery = RegisteredDelivery.DeliveryReceipt;
+                    var udh = new Udh(segId, totalSegments, i+1); // ID, Total, part
                     sm.SetMessageText(messages[i], defaultEncoding, udh); // send parts of the message + all other UDH settings
                     yield return sm;
                 }
             }
             else
             {
+                SubmitSm sm = CreateSubmitSm(smppEncodingService, destAddress, srcAddress);
+                sm.DataCoding = defaultEncoding;
+                if (SubmitUserMessageReference)
+                    sm.SetOptionalParamString(Lib.Protocol.Tlv.Tag.user_message_reference, UserMessageReference);
+
+                if (vRegisterDeliveryNotification)
+                    sm.RegisteredDelivery = RegisteredDelivery.DeliveryReceipt;
                 sm.SetMessageBytes(bytes);
                 yield return sm;
             }
         }
 
-        protected virtual SubmitSm CreateSubmitSm(SmppEncodingService smppEncodingService, SmppAddress destAddress = null, SmppAddress srcAddress = null)
+        protected virtual SubmitSm CreateSubmitSm(SmppEncodingService smppEncodingService,
+            SmppAddress destAddress = null, SmppAddress srcAddress = null)
         {
             var sm = new SubmitSm(smppEncodingService, destAddress, srcAddress);
-
             return sm;
         }
 
@@ -121,7 +135,6 @@ namespace JamaaTech.Smpp.Net.Client
             }
 
             return result;
-
         }
 
         private static int GetMaxMessageLength(DataCoding encoding, bool includeUdh)
@@ -137,16 +150,19 @@ namespace JamaaTech.Smpp.Net.Client
                 case DataCoding.UCS2:
                     return includeUdh ? 67 : 70;
                 default:
-                    throw new InvalidOperationException("Invalid or unsuported encoding for text message ");
+                    throw new InvalidOperationException("Invalid or unsupported encoding for text message ");
             }
         }
+
         #endregion
 
         #region Overriden System.Object Members
+
         public override string ToString()
         {
             return vText == null ? "" : vText;
         }
+
         #endregion
     }
 }


### PR DESCRIPTION
The code for setting messageId in the SmppClient class has been updated to accommodate multiple messageIds. Previously, the 'ReceiptedMessageId' was directly updated with the new 'messageId'. With this change, if 'ReceiptedMessageId' already contains a value, the new 'messageId' is appended to it instead of replacing it. This allows the 'ReceiptedMessageId' to hold a history of all messageIds, helpful in cases where tracking multiple message transactions is needed.